### PR TITLE
Adding linktiles extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To add your widget to the list, please read the [contribution guidelines](CONTRI
 >
 > Extension widgets are not actively monitored by the Glance maintainers, use at your own risk.
 
+* [linktiles](https://gitlab.com/haondt/linktiles/) by @haondt - display your linkding bookmarks in a configurable mosaic
 * [Restic snapshot](https://github.com/not-first/restic-glance-extension) by @not-first - show the most recent snapshot and storage stats of a restic repo
 * [Tailscale devices](https://github.com/not-first/tailscale-glance-extension) by @not-first - show all devices inside to a Tailscale tailnet along with their connection status, update availability and IP
 * [Uptime Kuma](https://github.com/not-first/uptime-kuma-glance-extension/) by @not-first - show the status of Uptime Kuma services on a status page

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To add your widget to the list, please read the [contribution guidelines](CONTRI
 >
 > Extension widgets are not actively monitored by the Glance maintainers, use at your own risk.
 
-* [linktiles](https://gitlab.com/haondt/linktiles/) by @haondt - display your linkding bookmarks in a configurable mosaic
+* [linktiles](https://github.com/haondt/linktiles/) by @haondt - display your linkding bookmarks in a configurable mosaic
 * [Restic snapshot](https://github.com/not-first/restic-glance-extension) by @not-first - show the most recent snapshot and storage stats of a restic repo
 * [Tailscale devices](https://github.com/not-first/tailscale-glance-extension) by @not-first - show all devices inside to a Tailscale tailnet along with their connection status, update availability and IP
 * [Uptime Kuma](https://github.com/not-first/uptime-kuma-glance-extension/) by @not-first - show the status of Uptime Kuma services on a status page


### PR DESCRIPTION
Adding a link to my project, [_linktiles_](https://github.com/haondt/linktiles). It is a standalone service but it has a built-in Glance extension. Its purpose is to display bookmarks from a [_linkding_](https://github.com/sissbruecker/linkding) instance in a configurable mosaic.

![image](https://github.com/user-attachments/assets/f4e35402-b9b3-4ff3-9c92-ab0d24d06b32)
