### PR TITLE
Add iCal Events List

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,6 @@ Custom API widgets are much easier to setup and usually only require a copy-past
 >
 > Extension widgets are not actively monitored by the maintainers of Glance, use them at your own risk.
 * [Google Calendar List](https://github.com/anant-j/glance-GoogleCalendar) by @anant-j - List Google Calendar upcoming events
+* [iCal (ICS) Calendar List](https://github.com/AWildLeon/Glance-iCal-Events) by @AWildLeon - List a ICS File's upcoming events (Like [Google Calendar List](https://github.com/anant-j/glance-GoogleCalendar))
 * [linktiles](https://github.com/haondt/linktiles/) by @haondt - display your linkding bookmarks in a configurable mosaic
 * [Restic snapshot](https://github.com/not-first/restic-glance-extension) by @not-first - show the most recent snapshot and storage stats of a restic repo


### PR DESCRIPTION
It’s like @anant-j’s [Google Calendar List](https://github.com/anant-j/glance-GoogleCalendar) but for iCal. I’ve used his widget and rewritten the entire API for iCal (ICS URLs).

![image](https://github.com/user-attachments/assets/808b42db-c2ed-4175-9688-0249e69342d0)

The linked repository ([https://github.com/AWildLeon/Glance-iCal-Events](https://github.com/AWildLeon/Glance-iCal-Events)) contains the configuration steps and Glance Config.