### PR TITLE
Updated Sonarr widget for v0.8.2

### DIFF
--- a/widgets/sonarr-releases-by-ralphocdol/README.md
+++ b/widgets/sonarr-releases-by-ralphocdol/README.md
@@ -66,7 +66,7 @@
                     TBA
                     {{ end }}
                   </p>
-                  {{ if gt (len "series.genres") 0 }}
+                  {{ if gt (len (.Array "series.genres")) 0 }}
                   <ul class="attachments margin-top-20">
                     {{ range .Array "series.genres" }}
                       <li>{{ .String "" }}</li>


### PR DESCRIPTION
With the release of v0.8, some features were added in the request usage, parameters can now accept `now | startOfDay` which is needed to use for the Sonarr's API parameter `start`.

This update makes sure it retains the yesterday's Sonarr release for those who uses `grabbed`. This also make use of the config `options:` to simplify user variables.