### PR TITLE
Update Widget URL in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,6 @@ Custom API widgets are much easier to setup and usually only require a copy-past
 > [!WARNING]
 >
 > Extension widgets are not actively monitored by the maintainers of Glance, use them at your own risk.
-* [iCal (ICS) Calendar List](https://github.com/AWildLeon/Glance-iCal-Events) by @AWildLeon - List a ICS File's upcoming events (Like [Google Calendar List](https://github.com/anant-j/glance-GoogleCalendar))
+* [iCal (ICS) Calendar List](https://github.com/AWildLeon/Glance-iCal-Events) by @AWildLeon - List a ICS File's upcoming events (Like [Google Calendar List](widgets/google-calendar-list-by-anant-j/README.md))
 * [linktiles](https://github.com/haondt/linktiles/) by @haondt - display your linkding bookmarks in a configurable mosaic
 * [Restic snapshot](https://github.com/not-first/restic-glance-extension) by @not-first - show the most recent snapshot and storage stats of a restic repo


### PR DESCRIPTION
Simple URL change from external repository to custom-api widget.

The external repository https://github.com/anant-j/glance-GoogleCalendar will be deleted after this PR is completed as all logic has now moved to [Google Calendar List Widget](https://github.com/glanceapp/community-widgets/blob/main/widgets/google-calendar-list-by-anant-j/README.md). 