### PR TITLE
bugfix: The device inactivity condition was not handled correctly.

### DIFF
--- a/widgets/spotify-player-by-anant-j/README.md
+++ b/widgets/spotify-player-by-anant-j/README.md
@@ -35,6 +35,9 @@ Choose from one of the following otpions:
           | withHeader "Authorization" (print "Bearer " $accessToken)
           | getResponse          
       }}
+      {{ if eq $currentlyPlaying.Response.StatusCode 204 }}
+        <p style="margin-right:10px;">Device is inactive</p>
+      {{ end}}
       {{ $isCurrentlyPlaying := $currentlyPlaying.JSON.Bool "is_playing" }}
       {{ $isDeviceActive := $currentlyPlaying.JSON.Bool "device.is_active" }}
       {{ $isPrivateSession := $currentlyPlaying.JSON.Bool "device.is_private_session" }}


### PR DESCRIPTION
The handling of device inactivity wasn’t implemented properly earlier. When the device is inactive, the request:

```yml
{{ $currentlyPlaying := newRequest "https://api.spotify.com/v1/me/player" 
                    | withHeader "Authorization" (print "Bearer " $accessToken)
                    | getResponse          
                }}
```                

returns an empty response with a 204 status code.

To address this, I’ve added a new check for this specific condition. Previously, since this case wasn’t accounted for, the widget would display nothing whenever the device was inactive.

Before:

![image](https://github.com/user-attachments/assets/83ecf471-af99-4a40-8324-cd9a2d65c616)

After:

![image](https://github.com/user-attachments/assets/1d2f734c-15d7-4122-a838-bf59984e2239)
