### PR TITLE
Improve device inactivity handling, styling, and add play from queue feature.

### DIFF
--- a/widgets/spotify-player-by-anant-j/README.md
+++ b/widgets/spotify-player-by-anant-j/README.md
@@ -35,6 +35,9 @@ Choose from one of the following otpions:
           | withHeader "Authorization" (print "Bearer " $accessToken)
           | getResponse          
       }}
+      {{ if eq $currentlyPlaying.Response.StatusCode 204 }}
+        <p style="margin-right:10px;">Device is inactive</p>
+      {{ end}}
       {{ $isCurrentlyPlaying := $currentlyPlaying.JSON.Bool "is_playing" }}
       {{ $isDeviceActive := $currentlyPlaying.JSON.Bool "device.is_active" }}
       {{ $isPrivateSession := $currentlyPlaying.JSON.Bool "device.is_private_session" }}
@@ -75,7 +78,7 @@ Choose from one of the following otpions:
           {{ else if $isPrivateSession }}
           <p style="margin-right:10px;">Private session is<br> active on {{ $deviceName }}</p> 
           {{ else }}
-          <p style="margin-right:10px;">Device is inactive</p>
+          <p style="margin-right:10px;">Error</p>
           {{ end }}
         </div>
         {{ end }}

--- a/widgets/spotify-player-by-anant-j/README.md
+++ b/widgets/spotify-player-by-anant-j/README.md
@@ -2,15 +2,15 @@
 
 # !!!!!!! IMPORTANT - PLEASE READ
 > [!CAUTION]     
-> Using the play(▶) and pause(⏸) buttons sends a request directly from the browser to Spotify's Play/Pause API's respectively. These PUT requests require the bearer token to be sent in the auth header, which means the $accessToken is exposed to the client-side/browser.  
+> Using the play(▶) and pause(⏸) buttons, or clicking on any song in the queue sends a request directly from the browser to Spotify's Play/Pause API's respectively. These PUT requests require the bearer token to be sent in the auth header, which means the $accessToken is exposed to the client-side/browser.  
 There are many security implications of this. For example, if a malicious actor get's access to this token, they can completely control and view your Spotify playlists/currently playing.  
 Please use this at your own risk. [Spotify Authorization](https://developer.spotify.com/documentation/web-api/tutorials/code-flow)  
 It is highly suggested to use [Glance Auth](https://github.com/glanceapp/glance/releases/tag/v0.8.0#g-rh-7). However, please note using this does not mitigate the above mentioned security risk.
 
 Choose from one of the following otpions:  
-1. Use Play/Pause in current-implementation at your own risk.
-2. Move Play/Pause functionality behind an external service so accessToken is not exposed on client-side.
-3. Remove Play/Pause from config below and the $accessToken will not be revealed on client-side.    
+1. Use Play/Pause, and Play from queue in current-implementation at your own risk.
+2. Move Play/Pause, and Play from queue functionality behind an external service so accessToken is not exposed on client-side.
+3. Remove Play/Pause, and Play from queue from config below and the $accessToken will not be revealed on client-side.    
 
 <hr>
 

--- a/widgets/spotify-player-by-anant-j/README.md
+++ b/widgets/spotify-player-by-anant-j/README.md
@@ -16,9 +16,8 @@ Choose from one of the following otpions:
 
 ```yaml
 - type: custom-api
-  hide-header: true
+  title: Spotify
   cache: 1s
-  frameless: true
   template: |
     {{
       $tokenRes := newRequest "https://accounts.spotify.com/api/token"
@@ -54,8 +53,8 @@ Choose from one of the following otpions:
         {{ $artist := $data.String "currently_playing.artists.0.name" }}
 
         {{ if gt (len $artist) 0 }}
-        <div class="size-h1">Spotify Now Playing</div>
-        <div class="widget-content-frame flex flex-row items-center gap-20">
+        <div class="size-h5">NOW PLAYING</div>
+        <div class="widget-content-frame flex flex-row items-center gap-20" style="padding: 4px; margin-top: 4px; margin-bottom: 4px;">
           <div>
             <img src="{{ $data.String "currently_playing.album.images.0.url" }}" style="border-radius: 5px; width: 5rem;" class="card">
           </div>
@@ -84,10 +83,10 @@ Choose from one of the following otpions:
         {{ end }}
 
         {{ if gt (len $queue) 0 }}
-          <div class="size-h1 color-muted font-bold">Upcoming:</div>
+          <div class="size-h5 color-muted font-bold" style="margin-top: 10px;">UPCOMING:</div>
           {{ range $i, $track := $queue }}
             {{ if lt $i 5 }}
-              <div class="widget-content-frame flex flex-row items-center gap-20">
+              <div class="widget-content-frame flex flex-row items-center gap-20" style="padding: 4px; margin-top: 4px; margin-bottom: 4px;">
                 <div>
                   <img src="{{ $track.String "album.images.0.url" }}" style="border-radius: 5px; width: 5rem;" class="card">
                 </div>

--- a/widgets/spotify-player-by-anant-j/README.md
+++ b/widgets/spotify-player-by-anant-j/README.md
@@ -86,7 +86,21 @@ Choose from one of the following otpions:
           <div class="size-h5 color-muted font-bold" style="margin-top: 10px;">UPCOMING:</div>
           {{ range $i, $track := $queue }}
             {{ if lt $i 5 }}
-              <div class="widget-content-frame flex flex-row items-center gap-20" style="padding: 4px; margin-top: 4px; margin-bottom: 4px;">
+              <div
+                class="widget-content-frame flex flex-row items-center gap-20"
+                style="padding: 4px; margin-top: 4px; margin-bottom: 4px; cursor: pointer;"
+                onclick="(function(){
+                  for (let j = 0; j < {{ add $i 1}}; j++) {
+                    fetch('https://api.spotify.com/v1/me/player/next', {
+                      method: 'POST',
+                      headers: {
+                        'Authorization': 'Bearer {{ $accessToken }}'
+                      }
+                    });
+                  }
+                  setTimeout(() => location.reload(), 2000);
+                })()"
+              >
                 <div>
                   <img src="{{ $track.String "album.images.0.url" }}" style="border-radius: 5px; width: 5rem;" class="card">
                 </div>


### PR DESCRIPTION
This PR includes a set of improvements and fixes for the Spotify Player widget:

**Bugfix**

- Properly handle device inactivity by checking for empty responses (204 No Content) from the Spotify API. Previously, this caused the widget to display nothing when no device was active.

**Improvements**

- Refined styling of .widget-content-frame elements:

  - Added padding and margins

  - Enabled frame and title display

  - Adjusted heading levels for better layout consistency
  
**New Feature**

- Added the ability to click on items in the upcoming queue to skip directly to that track.

**Other**

- Update README.md

**Screenshots**

- Before

![image](https://github.com/user-attachments/assets/cbaa0a3c-8af6-4787-b216-58ebd65f4897)

- After

![image](https://github.com/user-attachments/assets/98f75127-6130-42d4-9a90-645b1df485ca)

- Bugfix

![image](https://github.com/user-attachments/assets/d342ebfc-89c2-4139-9a26-2ed5ec306844)

- New Feature: Play from queue

https://github.com/user-attachments/assets/2590e7b5-d9c0-4661-9acb-90ae57e07faa




