### PR TITLE
Speedtest-tracker: wrong env variable provided

### DIFF
--- a/widgets/speedtest-tracker-by-not-first/README.md
+++ b/widgets/speedtest-tracker-by-not-first/README.md
@@ -112,5 +112,5 @@
 
 ## Environment variables
 
-- `SPEEDTEST_TRACKER_URL` - The URL of the Speedtest Tracker instance (e.g `http://my.speedtest-tracker.instance`)
+- `SPEEDTEST_URL` - The URL of the Speedtest Tracker instance (e.g `http://my.speedtest-tracker.instance`)
 - `SPEEDTEST_TRACKER_API_TOKEN` - Your Speedtest Tracker API token


### PR DESCRIPTION
in code - SPEEDTEST_URL
in env variables - SPEEDTEST_TRACKER_URL

```yml
...
subrequests:
    stats:
      url: ${SPEEDTEST_URL}/api/v1/stats
```
however in the end of readme it says:

```md
## Environment variables

- `SPEEDTEST_TRACKER_URL` - The URL of the Speedtest Tracker instance (e.g `http://my.speedtest-tracker.instance`)
- `SPEEDTEST_TRACKER_API_TOKEN` - Your Speedtest Tracker API token
```

probably typo by author