### PR TITLE
Update README.md

### DIFF
--- a/widgets/proxmox-ve-nodes-by-ralphocdol/README.md
+++ b/widgets/proxmox-ve-nodes-by-ralphocdol/README.md
@@ -5,7 +5,7 @@
   title: PROXMOX-VE NODES
   title-url: https://${PROXMOXVE_URL}
   cache: 1m
-  url: https://${PROXMOXVE_URL}/api2/json/cluster/resources?type=node
+  url: https://${PROXMOXVE_URL}/api2/json/nodes
   allow-insecure: true
   headers:
     Accept: application/json


### PR DESCRIPTION
fix(api): Update Proxmox API endpoint for node listing

Changed the API endpoint from '/api2/json/cluster/resources?type=node' to '/api2/json/nodes' to use the correct Proxmox API endpoint for listing nodes. The previous endpoint was using a more generic resources query when a dedicated nodes endpoint is available.

<img width="630" height="198" alt="image" src="https://github.com/user-attachments/assets/698eb27a-0647-4aa6-bb68-8fab23371330" />
