### PR TITLE
Fix URL bug in Epic Games Widget

### DIFF
--- a/widgets/epic-free-widget-by-marocainperdu/README.md
+++ b/widgets/epic-free-widget-by-marocainperdu/README.md
@@ -35,7 +35,11 @@ Add the following to your dashboard configuration:
             {{ $price := .String "price.totalPrice.discountPrice" }}
             {{ $hasPromo := gt (len (.Array "promotions.promotionalOffers")) 0 }}
             {{ if and $hasPromo (eq $price "0") }}
-              <a href="https://store.epicgames.com/en-US/p/{{ .String "productSlug" }}" target="_blank" class="card">
+              {{ $gamePage := .String "productSlug" }}
+              {{ if gt (len (.Array "catalogNs.mappings")) 0 }}
+                {{ $gamePage = .String "catalogNs.mappings.0.pageSlug" }}
+              {{end }}
+              <a href="https://store.epicgames.com/en-US/p/{{ $gamePage }}" target="_blank" class="card">
                 {{ $title := .String "title" }}
                 {{ range .Array "keyImages" }}
                   {{ if eq (.String "type") "OfferImageWide" }}

--- a/widgets/epic-free-widget-by-marocainperdu/README.md
+++ b/widgets/epic-free-widget-by-marocainperdu/README.md
@@ -36,8 +36,8 @@ Add the following to your dashboard configuration:
             {{ $hasPromo := gt (len (.Array "promotions.promotionalOffers")) 0 }}
             {{ if and $hasPromo (eq $price "0") }}
               {{ $gamePage := .String "productSlug" }}
-              {{ if gt (len (.Array "catalogNs.mappings")) 0 }}
-                {{ $gamePage = .String "catalogNs.mappings.0.pageSlug" }}
+              {{ if gt (len (.Array "offerMappings")) 0 }}
+                {{ $gamePage = .String "offerMappings.0.pageSlug" }}
               {{end }}
               <a href="https://store.epicgames.com/en-US/p/{{ $gamePage }}" target="_blank" class="card">
                 {{ $title := .String "title" }}


### PR DESCRIPTION
## Problem
The Epic Games Free Games widget seems to have a bug in the URL with the latest release. It seems like Epic does not always fill the `productSlug` section (it might be related to games with various versions or DLC?). 
## Fix
Looking through the JSON response, I found that `offerMappings` looks to be non-empty and have the attribute `pageSlug` when the `productSlug` is empty. So I added a quick check to see if it exists instead and override the URL.

### Before Fix
<img width="299" height="257" alt="epic_game_store_bug" src="https://github.com/user-attachments/assets/b187ba0a-550b-47bf-869d-d9eb444d3ce5" />

### After Fix
<img width="299" height="257" alt="epic_game_store_bug_fix" src="https://github.com/user-attachments/assets/2a90d6a3-dfd5-42cc-bf8a-75b6bffe532e" />

