### PR TITLE
updating Tailscale widget to use oauth client (no more api key expiry)

### DIFF
--- a/widgets/tailscale-devices-by-not-first/README.md
+++ b/widgets/tailscale-devices-by-not-first/README.md
@@ -1,5 +1,7 @@
 # Tailscale Devices Widget
 
+![](preview.png)
+
 A widget for Glance that displays all devices in your Tailscale tailnet, showing their connection status, update availability, and IP addresses.
 
 ## Option 1: API Key (Recommended)
@@ -15,8 +17,6 @@ The standard implementation using Tailscale API keys. Simple to set up but requi
 
 2. **Configure Widget:**
    - Set the `TAILSCALE_API_KEY` environment variable to your generated key
-
-### Configuration
 
 ```yaml
 - type: custom-api
@@ -156,8 +156,6 @@ An alternative implementation that uses automatically refreshing OAuth tokens, e
 2. **Configure Widget:**
    - Point the `url` to your OAuth proxy container endpoint
    - The proxy handles all authentication automatically
-
-### Configuration
 
 ```yaml
 - type: custom-api

--- a/widgets/tailscale-devices-by-not-first/README.md
+++ b/widgets/tailscale-devices-by-not-first/README.md
@@ -1,287 +1,207 @@
-![](preview.png)
+# Tailscale Devices Widget
+
+A widget for Glance that displays all devices in your Tailscale tailnet, showing their connection status, update availability, and IP addresses.
+
+## Option 1: API Key (Recommended)
+
+The standard implementation using Tailscale API keys. Simple to set up but requires manual key renewal every 90 days maximum.
+
+### Setup
+
+1. **Generate API Key:**
+   - Go to [Tailscale admin console](https://login.tailscale.com/admin/settings/keys)
+   - Generate a new API key (maximum 90-day expiration)
+   - Copy the key
+
+2. **Configure Widget:**
+   - Set the `TAILSCALE_API_KEY` environment variable to your generated key
+
+### Configuration
 
 ```yaml
-        - type: custom-api
-          title: Tailscale Devices
-          title-url: https://login.tailscale.com/admin/machines
-          options:
-            auth_mode: "oauth_proxy"  # choose "api_key" or "oauth_proxy"
-          # Main URL (OAuth Proxy mode)
-          url: http://tailscale-token-manager:1180/devices
-          cache: 30s
-          subrequests:
-            api_data:
-              url: https://api.tailscale.com/api/v2/tailnet/-/devices
-              headers:
-                Authorization: Bearer ${TAILSCALE_API_KEY}
-          template: |
-            {{ if eq .Options.auth_mode "api_key" }}
-              {{ $data := .Subrequest "api_data" }}
-              {{ if ne $data.Response.StatusCode 200 }}
-                <div class="widget-error-header">
-                  <div class="color-negative size-h3">ERROR</div>
-                  <svg class="widget-error-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"></path>
-                  </svg>
-                </div>
-                <p class="break-all">Failed to fetch Tailscale devices: {{ $data.Response.Status }}</p>
-              {{ else }}
-                {{/* Set to true if you'd like an indicator for online devices */}}
-                {{ $enableOnlineIndicator := true }}
-
-            <style>
-              .device-info-container {
-                position: relative;
-                overflow: hidden;
-                height: 1.5em;
-              }
-              .device-info {
-                display: flex;
-                transition: transform 0.2s ease, opacity 0.2s ease;
-              }
-              .device-ip {
-                position: absolute;
-                top: 0;
-                left: 0;
-                transform: translateY(-100%);
-                opacity: 0;
-                transition: transform 0.2s ease, opacity 0.2s ease;
-              }
-              .device-info-container:hover .device-info {
-                transform: translateY(100%);
-                opacity: 0;
-              }
-              .device-info-container:hover .device-ip {
-                transform: translateY(0);
-                opacity: 1;
-              }
-              .update-indicator {
-                width: 8px;
-                height: 8px;
-                border-radius: 50%;
-                background-color: var(--color-warning);
-                display: inline-block;
-                margin-left: 4px;
-                vertical-align: middle;
-              }
-              .offline-indicator {
-                width: 8px;
-                height: 8px;
-                border-radius: 50%;
-                background-color: var(--color-negative);
-                display: inline-block;
-                margin-left: 4px;
-                vertical-align: middle;
-              }
-              .online-indicator {
-                width: 8px;
-                height: 8px;
-                border-radius: 50%;
-                background-color: var(--color-positive);
-                display: inline-block;
-                margin-left: 4px;
-                vertical-align: middle;
-              }
-              .device-name-container {
-                display: flex;
-                align-items: center;
-                gap: 8px;
-              }
-              .indicators-container {
-                display: flex;
-                align-items: center;
-                gap: 4px;
-              }
-            </style>
-            <ul class="list list-gap-10 collapsible-container" data-collapse-after="4">
-              {{ range $data.JSON.Array "devices" }}
-              <li>
-                <div class="flex items-center gap-10">
-                  <div class="device-name-container grow">
-                    <span class="size-h4 block text-truncate color-primary">
-                      {{ findMatch "^([^.]+)" (.String "name") }}
-                    </span>
-                    <div class="indicators-container">
-                      {{ if (.Bool "updateAvailable") }}
-                      <span class="update-indicator" data-popover-type="text" data-popover-text="Update Available"></span>
-                      {{ end }}
-
-                      {{ $lastSeen := .String "lastSeen" | parseTime "rfc3339" }}
-                      {{ if not ($lastSeen.After (offsetNow "-10s")) }}
-                      {{ $lastSeenTimezoned := $lastSeen.In now.Location }}
-                      <span class="offline-indicator" data-popover-type="text"
-                        data-popover-text="Offline - Last seen {{ $lastSeenTimezoned.Format " Jan 2 3:04pm" }}"></span>
-                      {{ end }}
-                    </div>
-                  </div>
-                </div>
-                <div class="device-info-container">
-                  <ul class="list-horizontal-text device-info">
-                    <li>{{ .String "os" }}</li>
-                    <li>{{ .String "user" }}</li>
-                  </ul>
-                  <div class="device-ip">
-                    {{ .String "addresses.0"}}
-                  </div>
-                </div>
-              </li>
-              {{ end }}
-            </ul>
-              {{ end }}
-            {{ else }}
-              {{ if ne .Response.StatusCode 200 }}
-                <div class="widget-error-header">
-                  <div class="color-negative size-h3">ERROR</div>
-                  <svg class="widget-error-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"></path>
-                  </svg>
-                </div>
-                <p class="break-all">Failed to fetch Tailscale devices: {{ .Response.Status }}</p>
-              {{ else }}
-                {{/* Set to true if you'd like an indicator for online devices */}}
-                {{ $enableOnlineIndicator := true }}
-
-                <style>
-                  .device-info-container {
-                    position: relative;
-                    overflow: hidden;
-                    height: 1.5em;
-                  }
-                  .device-info {
-                    display: flex;
-                    transition: transform 0.2s ease, opacity 0.2s ease;
-                  }
-                  .device-ip {
-                    position: absolute;
-                    top: 0;
-                    left: 0;
-                    transform: translateY(-100%);
-                    opacity: 0;
-                    transition: transform 0.2s ease, opacity 0.2s ease;
-                  }
-                  .device-info-container:hover .device-info {
-                    transform: translateY(100%);
-                    opacity: 0;
-                  }
-                  .device-info-container:hover .device-ip {
-                    transform: translateY(0);
-                    opacity: 1;
-                  }
-                  .update-indicator {
-                    width: 8px;
-                    height: 8px;
-                    border-radius: 50%;
-                    background-color: var(--color-primary);
-                    display: inline-block;
-                    margin-left: 4px;
-                    vertical-align: middle;
-                  }
-                  .offline-indicator {
-                    width: 8px;
-                    height: 8px;
-                    border-radius: 50%;
-                    background-color: var(--color-negative);
-                    display: inline-block;
-                    margin-left: 4px;
-                    vertical-align: middle;
-                  }
-                  .online-indicator {
-                    width: 8px;
-                    height: 8px;
-                    border-radius: 50%;
-                    background-color: var(--color-positive);
-                    display: inline-block;
-                    margin-left: 4px;
-                    vertical-align: middle;
-                  }
-                  .device-name-container {
-                    display: flex;
-                    align-items: center;
-                    gap: 8px;
-                  }
-                  .indicators-container {
-                    display: flex;
-                    align-items: center;
-                    gap: 4px;
-                  }
-                </style>
-                <ul class="list list-gap-10 collapsible-container" data-collapse-after="4">
-                  {{ range .JSON.Array "devices" }}
-                  <li>
-                    <div class="flex items-center gap-10">
-                      <div class="device-name-container grow">
-                        <span class="size-h4 block text-truncate color-primary">
-                          {{ findMatch "^([^.]+)" (.String "name") }}
-                        </span>
-                        <div class="indicators-container">
-                          {{ if (.Bool "updateAvailable") }}
-                          <span class="update-indicator" data-popover-type="text" data-popover-text="Update Available"></span>
-                          {{ end }}
-                          {{ $lastSeen := .String "lastSeen" | parseTime "rfc3339" }}
-                          {{ if not ($lastSeen.After (offsetNow "-10s")) }}
-                          {{ $lastSeenTimezoned := $lastSeen.In now.Location }}
-                          <span class="offline-indicator" data-popover-type="text"
-                            data-popover-text="Offline - Last seen {{ $lastSeenTimezoned.Format " Jan 2 3:04pm" }}"></span>
-                          {{ end }}
-                        </div>
-                      </div>
-                    </div>
-                    <div class="device-info-container">
-                      <ul class="list-horizontal-text device-info">
-                        <li>{{ .String "os" }}</li>
-                        <li>{{ .String "user" }}</li>
-                      </ul>
-                      <div class="device-ip">
-                        {{ .String "addresses.0"}}
-                      </div>
-                    </div>
-                  </li>
-                  {{ end }}
-                </ul>
-              {{ end }}
+- type: custom-api
+  title: Tailscale Devices
+  url: https://api.tailscale.com/api/v2/tailnet/YOUR_TAILNET/devices
+  headers:
+    Authorization: Bearer YOUR_API_KEY
+  icon: si:tailscale
+  cache: 1m
+  size: medium
+  template: |
+    {{ $devices := .Data.devices }}
+    {{ if $devices }}
+    <div class="list">
+      {{ range $devices }}
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-item-title">
+            {{ .hostname }}
+            {{ if .updateAvailable }}
+              <span class="list-item-status">Update Available</span>
             {{ end }}
-
+          </div>
+          <div class="list-item-subtitle">
+            {{ .addresses | join ", " }}
+          </div>
+        </div>
+        <div class="list-item-right">
+          <div class="list-item-status {{ if .online }}online{{ else }}offline{{ end }}">
+            {{ if .online }}Online{{ else }}Offline{{ end }}
+          </div>
+        </div>
+      </div>
+      {{ end }}
+    </div>
+    {{ else }}
+    <div class="list">
+      <div class="list-item">
+        <div class="list-item-title">No devices found</div>
+      </div>
+    </div>
+    {{ end }}
 ```
 
-## Configuration Options
+## Option 2: OAuth Proxy (Alternative)
 
-### `auth_mode` (required)
-- `"api_key"` - Use Tailscale API key authentication (default)
-- `"oauth_proxy"` - Use OAuth proxy with automatic token refresh
+An alternative implementation that uses automatically refreshing OAuth tokens, eliminating the need for manual key renewal. Created by @5at0ri, requires [5at0ri's OAuth Proxy](https://github.com/5at0ri/tailscale-token-manager).
 
-## Usage Examples
+### Setup
 
-### API Key Mode (Default)
+1. **Deploy OAuth Proxy:**
+   - Set up OAuth client credentials in your [Tailscale admin console](https://login.tailscale.com/admin/settings/oauth)
+   - Deploy the [OAuth Proxy container](https://github.com/5at0ri/tailscale-token-manager)
+   - Configure it with your OAuth Client ID and Client Secret
+
+2. **Configure Widget:**
+   - Point the `url` to your OAuth proxy container endpoint
+   - The proxy handles all authentication automatically
+
+### Configuration
+
 ```yaml
-options:
-  auth_mode: "api_key"
+- type: custom-api
+  title: Tailscale Devices
+  title-url: https://login.tailscale.com/admin/machines
+  url: http://tailscale-token-manager:1180/devices  # URL to your OAuth proxy container
+  cache: 10s
+  template: |
+    {{/* User Variables */}}
+    {{/* Set to true if you'd like an indicator for online devices */}}
+    {{ $enableOnlineIndicator := false }}
+
+    <style>
+      .device-info-container {
+        position: relative;
+        overflow: hidden;
+        height: 1.5em;
+      }
+
+      .device-info {
+        display: flex;
+        transition: transform 0.2s ease, opacity 0.2s ease;
+      }
+
+      .device-ip {
+        position: absolute;
+        top: 0;
+        left: 0;
+        transform: translateY(-100%);
+        opacity: 0;
+        transition: transform 0.2s ease, opacity 0.2s ease;
+      }
+
+      .device-info-container:hover .device-info {
+        transform: translateY(100%);
+        opacity: 0;
+      }
+
+      .device-info-container:hover .device-ip {
+        transform: translateY(0);
+        opacity: 1;
+      }
+
+      .update-indicator {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background-color: var(--color-primary);
+        display: inline-block;
+        margin-left: 4px;
+        vertical-align: middle;
+      }
+
+      .offline-indicator {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background-color: var(--color-negative);
+        display: inline-block;
+        margin-left: 4px;
+        vertical-align: middle;
+      }
+
+      .online-indicator {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background-color: var(--color-positive);
+        display: inline-block;
+        margin-left: 4px;
+        vertical-align: middle;
+      }
+
+      .device-name-container {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .indicators-container {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+    </style>
+    <ul class="list list-gap-10 collapsible-container" data-collapse-after="4">
+      {{ range .JSON.Array "devices" }}
+      <li>
+        <div class="flex items-center gap-10">
+          <div class="device-name-container grow">
+            <span class="size-h4 block text-truncate color-primary">
+              {{ findMatch "^([^.]+)" (.String "name") }}
+            </span>
+            <div class="indicators-container">
+              {{ if (.Bool "updateAvailable") }}
+              <span class="update-indicator" data-popover-type="text" data-popover-text="Update Available"></span>
+              {{ end }}
+
+              {{ $lastSeen := .String "lastSeen" | parseTime "rfc3339" }}
+              {{ if not ($lastSeen.After (offsetNow "-10s")) }}
+              {{ $lastSeenTimezoned := $lastSeen.In now.Location }}
+              <span class="offline-indicator" data-popover-type="text"
+                data-popover-text="Offline - Last seen {{ $lastSeenTimezoned.Format " Jan 2 3:04pm" }}"></span>
+              {{ else if $enableOnlineIndicator }}
+                <span class="online-indicator" data-popover-type="text" data-popover-text="Online"></span>
+              {{ end }}
+            </div>
+          </div>
+        </div>
+        <div class="device-info-container">
+          <ul class="list-horizontal-text device-info">
+            <li>{{ .String "os" }}</li>
+            <li>{{ .String "user" }}</li>
+          </ul>
+          <div class="device-ip">
+            {{ .String "addresses.0"}}
+          </div>
+        </div>
+      </li>
+      {{ end }}
+    </ul>
 ```
 
-### OAuth Proxy Mode (Automatic Token Refresh)
-```yaml
-options:
-  auth_mode: "oauth_proxy"
-```
+## Notes
 
-## Authentication Modes
-
-### API Key Mode
-- Uses your Tailscale API key directly
-- Requires manual renewal every 90 days
-- **Environment variable required:** `TAILSCALE_API_KEY`
-
-### OAuth Proxy Mode
-- Uses the [Tailscale Token Manager](https://github.com/5at0ri/tailscale-token-manager) container
-- Automatically refreshes OAuth tokens - no manual updates needed
-- **Prerequisites:**
-  - Deploy the `tailscale-token-manager` container
-  - Configure OAuth application in Tailscale admin console
-  - Ensure the token manager is accessible at `tailscale-token-manager:1180`
-
-## Environment Variables
-
-- `TAILSCALE_API_KEY`: Your Tailscale API key (required for `auth_mode: "api_key"`)
-- `TZ`: Container timezone for correct timestamps (optional)
-
-## Credits
-[5at0ri](https://github.com/5at0ri) - Incorporated oauth into the widget as an option and made the token manager (https://github.com/5at0ri/tailscale-token-manager)
+- **API Key Mode:** Simpler setup, requires manual renewal every 90 days
+- **OAuth Proxy Mode:** Automatic token refresh, requires additional container setup
+- Both implementations provide identical device information and functionality

--- a/widgets/tailscale-devices-by-not-first/README.md
+++ b/widgets/tailscale-devices-by-not-first/README.md
@@ -21,44 +21,125 @@ The standard implementation using Tailscale API keys. Simple to set up but requi
 ```yaml
 - type: custom-api
   title: Tailscale Devices
-  url: https://api.tailscale.com/api/v2/tailnet/YOUR_TAILNET/devices
+  title-url: https://login.tailscale.com/admin/machines
+  url: https://api.tailscale.com/api/v2/tailnet/-/devices
   headers:
-    Authorization: Bearer YOUR_API_KEY
-  icon: si:tailscale
-  cache: 1m
-  size: medium
+    Authorization: Bearer ${TAILSCALE_API_KEY}
+  cache: 10m
   template: |
-    {{ $devices := .Data.devices }}
-    {{ if $devices }}
-    <div class="list">
-      {{ range $devices }}
-      <div class="list-item">
-        <div class="list-item-left">
-          <div class="list-item-title">
-            {{ .hostname }}
-            {{ if .updateAvailable }}
-              <span class="list-item-status">Update Available</span>
-            {{ end }}
-          </div>
-          <div class="list-item-subtitle">
-            {{ .addresses | join ", " }}
+    {{/* User Variables */}}
+    {{/* Set to true if you'd like an indicator for online devices */}}
+    {{ $enableOnlineIndicator := false }}
+
+    <style>
+      .device-info-container {
+        position: relative;
+        overflow: hidden;
+        height: 1.5em;
+      }
+
+      .device-info {
+        display: flex;
+        transition: transform 0.2s ease, opacity 0.2s ease;
+      }
+
+      .device-ip {
+        position: absolute;
+        top: 0;
+        left: 0;
+        transform: translateY(-100%);
+        opacity: 0;
+        transition: transform 0.2s ease, opacity 0.2s ease;
+      }
+
+      .device-info-container:hover .device-info {
+        transform: translateY(100%);
+        opacity: 0;
+      }
+
+      .device-info-container:hover .device-ip {
+        transform: translateY(0);
+        opacity: 1;
+      }
+
+      .update-indicator {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background-color: var(--color-primary);
+        display: inline-block;
+        margin-left: 4px;
+        vertical-align: middle;
+      }
+
+      .offline-indicator {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background-color: var(--color-negative);
+        display: inline-block;
+        margin-left: 4px;
+        vertical-align: middle;
+      }
+
+      .online-indicator {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background-color: var(--color-positive);
+        display: inline-block;
+        margin-left: 4px;
+        vertical-align: middle;
+      }
+
+      .device-name-container {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .indicators-container {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+    </style>
+    <ul class="list list-gap-10 collapsible-container" data-collapse-after="4">
+      {{ range .JSON.Array "devices" }}
+      <li>
+        <div class="flex items-center gap-10">
+          <div class="device-name-container grow">
+            <span class="size-h4 block text-truncate color-primary">
+              {{ findMatch "^([^.]+)" (.String "name") }}
+            </span>
+            <div class="indicators-container">
+              {{ if (.Bool "updateAvailable") }}
+              <span class="update-indicator" data-popover-type="text" data-popover-text="Update Available"></span>
+              {{ end }}
+
+              {{ $lastSeen := .String "lastSeen" | parseTime "rfc3339" }}
+              {{ if not ($lastSeen.After (offsetNow "-10s")) }}
+              {{ $lastSeenTimezoned := $lastSeen.In now.Location }}
+              <span class="offline-indicator" data-popover-type="text"
+                data-popover-text="Offline - Last seen {{ $lastSeenTimezoned.Format " Jan 2 3:04pm" }}"></span>
+              {{ else if $enableOnlineIndicator }}
+                <span class="online-indicator" data-popover-type="text" data-popover-text="Online"></span>
+              {{ end }}
+            </div>
           </div>
         </div>
-        <div class="list-item-right">
-          <div class="list-item-status {{ if .online }}online{{ else }}offline{{ end }}">
-            {{ if .online }}Online{{ else }}Offline{{ end }}
+        <div class="device-info-container">
+          <ul class="list-horizontal-text device-info">
+            <li>{{ .String "os" }}</li>
+            <li>{{ .String "user" }}</li>
+          </ul>
+          <div class="device-ip">
+            {{ .String "addresses.0"}}
           </div>
         </div>
-      </div>
+      </li>
       {{ end }}
-    </div>
-    {{ else }}
-    <div class="list">
-      <div class="list-item">
-        <div class="list-item-title">No devices found</div>
-      </div>
-    </div>
-    {{ end }}
+    </ul>
 ```
 
 ## Option 2: OAuth Proxy (Alternative)

--- a/widgets/tailscale-devices-by-not-first/README.md
+++ b/widgets/tailscale-devices-by-not-first/README.md
@@ -1,130 +1,284 @@
 ![](preview.png)
 
 ```yaml
-- type: custom-api
-  title: Tailscale Devices
-  title-url: https://login.tailscale.com/admin/machines
-  url: https://api.tailscale.com/api/v2/tailnet/-/devices
-  headers:
-    Authorization: Bearer ${TAILSCALE_API_KEY}
-  cache: 10m
-  template: |
-    {{/* User Variables */}}
-    {{/* Set to true if you'd like an indicator for online devices */}}
-    {{ $enableOnlineIndicator := false }}
+        - type: custom-api
+          title: Tailscale Devices
+          title-url: https://login.tailscale.com/admin/machines
+          options:
+            auth_mode: "oauth_proxy"  # choose "api_key" or "oauth_proxy"
+          # Main URL (OAuth Proxy mode)
+          url: http://tailscale-token-manager:1180/devices
+          cache: 30s
+          subrequests:
+            api_data:
+              url: https://api.tailscale.com/api/v2/tailnet/-/devices
+              headers:
+                Authorization: Bearer ${TAILSCALE_API_KEY}
+          template: |
+            {{ if eq .Options.auth_mode "api_key" }}
+              {{ $data := .Subrequest "api_data" }}
+              {{ if ne $data.Response.StatusCode 200 }}
+                <div class="widget-error-header">
+                  <div class="color-negative size-h3">ERROR</div>
+                  <svg class="widget-error-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"></path>
+                  </svg>
+                </div>
+                <p class="break-all">Failed to fetch Tailscale devices: {{ $data.Response.Status }}</p>
+              {{ else }}
+                {{/* Set to true if you'd like an indicator for online devices */}}
+                {{ $enableOnlineIndicator := true }}
 
-    <style>
-      .device-info-container {
-        position: relative;
-        overflow: hidden;
-        height: 1.5em;
-      }
+            <style>
+              .device-info-container {
+                position: relative;
+                overflow: hidden;
+                height: 1.5em;
+              }
+              .device-info {
+                display: flex;
+                transition: transform 0.2s ease, opacity 0.2s ease;
+              }
+              .device-ip {
+                position: absolute;
+                top: 0;
+                left: 0;
+                transform: translateY(-100%);
+                opacity: 0;
+                transition: transform 0.2s ease, opacity 0.2s ease;
+              }
+              .device-info-container:hover .device-info {
+                transform: translateY(100%);
+                opacity: 0;
+              }
+              .device-info-container:hover .device-ip {
+                transform: translateY(0);
+                opacity: 1;
+              }
+              .update-indicator {
+                width: 8px;
+                height: 8px;
+                border-radius: 50%;
+                background-color: var(--color-warning);
+                display: inline-block;
+                margin-left: 4px;
+                vertical-align: middle;
+              }
+              .offline-indicator {
+                width: 8px;
+                height: 8px;
+                border-radius: 50%;
+                background-color: var(--color-negative);
+                display: inline-block;
+                margin-left: 4px;
+                vertical-align: middle;
+              }
+              .online-indicator {
+                width: 8px;
+                height: 8px;
+                border-radius: 50%;
+                background-color: var(--color-positive);
+                display: inline-block;
+                margin-left: 4px;
+                vertical-align: middle;
+              }
+              .device-name-container {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+              }
+              .indicators-container {
+                display: flex;
+                align-items: center;
+                gap: 4px;
+              }
+            </style>
+            <ul class="list list-gap-10 collapsible-container" data-collapse-after="4">
+              {{ range $data.JSON.Array "devices" }}
+              <li>
+                <div class="flex items-center gap-10">
+                  <div class="device-name-container grow">
+                    <span class="size-h4 block text-truncate color-primary">
+                      {{ findMatch "^([^.]+)" (.String "name") }}
+                    </span>
+                    <div class="indicators-container">
+                      {{ if (.Bool "updateAvailable") }}
+                      <span class="update-indicator" data-popover-type="text" data-popover-text="Update Available"></span>
+                      {{ end }}
 
-      .device-info {
-        display: flex;
-        transition: transform 0.2s ease, opacity 0.2s ease;
-      }
-
-      .device-ip {
-        position: absolute;
-        top: 0;
-        left: 0;
-        transform: translateY(-100%);
-        opacity: 0;
-        transition: transform 0.2s ease, opacity 0.2s ease;
-      }
-
-      .device-info-container:hover .device-info {
-        transform: translateY(100%);
-        opacity: 0;
-      }
-
-      .device-info-container:hover .device-ip {
-        transform: translateY(0);
-        opacity: 1;
-      }
-
-      .update-indicator {
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        background-color: var(--color-primary);
-        display: inline-block;
-        margin-left: 4px;
-        vertical-align: middle;
-      }
-
-      .offline-indicator {
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        background-color: var(--color-negative);
-        display: inline-block;
-        margin-left: 4px;
-        vertical-align: middle;
-      }
-
-      .online-indicator {
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        background-color: var(--color-positive);
-        display: inline-block;
-        margin-left: 4px;
-        vertical-align: middle;
-      }
-
-      .device-name-container {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-      }
-
-      .indicators-container {
-        display: flex;
-        align-items: center;
-        gap: 4px;
-      }
-    </style>
-    <ul class="list list-gap-10 collapsible-container" data-collapse-after="4">
-      {{ range .JSON.Array "devices" }}
-      <li>
-        <div class="flex items-center gap-10">
-          <div class="device-name-container grow">
-            <span class="size-h4 block text-truncate color-primary">
-              {{ findMatch "^([^.]+)" (.String "name") }}
-            </span>
-            <div class="indicators-container">
-              {{ if (.Bool "updateAvailable") }}
-              <span class="update-indicator" data-popover-type="text" data-popover-text="Update Available"></span>
+                      {{ $lastSeen := .String "lastSeen" | parseTime "rfc3339" }}
+                      {{ if not ($lastSeen.After (offsetNow "-10s")) }}
+                      {{ $lastSeenTimezoned := $lastSeen.In now.Location }}
+                      <span class="offline-indicator" data-popover-type="text"
+                        data-popover-text="Offline - Last seen {{ $lastSeenTimezoned.Format " Jan 2 3:04pm" }}"></span>
+                      {{ end }}
+                    </div>
+                  </div>
+                </div>
+                <div class="device-info-container">
+                  <ul class="list-horizontal-text device-info">
+                    <li>{{ .String "os" }}</li>
+                    <li>{{ .String "user" }}</li>
+                  </ul>
+                  <div class="device-ip">
+                    {{ .String "addresses.0"}}
+                  </div>
+                </div>
+              </li>
               {{ end }}
-
-              {{ $lastSeen := .String "lastSeen" | parseTime "rfc3339" }}
-              {{ if not ($lastSeen.After (offsetNow "-10s")) }}
-              {{ $lastSeenTimezoned := $lastSeen.In now.Location }}
-              <span class="offline-indicator" data-popover-type="text"
-                data-popover-text="Offline - Last seen {{ $lastSeenTimezoned.Format " Jan 2 3:04pm" }}"></span>
-              {{ else if $enableOnlineIndicator }}
-                <span class="online-indicator" data-popover-type="text" data-popover-text="Online"></span>
+            </ul>
               {{ end }}
-            </div>
-          </div>
-        </div>
-        <div class="device-info-container">
-          <ul class="list-horizontal-text device-info">
-            <li>{{ .String "os" }}</li>
-            <li>{{ .String "user" }}</li>
-          </ul>
-          <div class="device-ip">
-            {{ .String "addresses.0"}}
-          </div>
-        </div>
-      </li>
-      {{ end }}
-    </ul>
+            {{ else }}
+              {{ if ne .Response.StatusCode 200 }}
+                <div class="widget-error-header">
+                  <div class="color-negative size-h3">ERROR</div>
+                  <svg class="widget-error-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"></path>
+                  </svg>
+                </div>
+                <p class="break-all">Failed to fetch Tailscale devices: {{ .Response.Status }}</p>
+              {{ else }}
+                {{/* Set to true if you'd like an indicator for online devices */}}
+                {{ $enableOnlineIndicator := true }}
+
+                <style>
+                  .device-info-container {
+                    position: relative;
+                    overflow: hidden;
+                    height: 1.5em;
+                  }
+                  .device-info {
+                    display: flex;
+                    transition: transform 0.2s ease, opacity 0.2s ease;
+                  }
+                  .device-ip {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    transform: translateY(-100%);
+                    opacity: 0;
+                    transition: transform 0.2s ease, opacity 0.2s ease;
+                  }
+                  .device-info-container:hover .device-info {
+                    transform: translateY(100%);
+                    opacity: 0;
+                  }
+                  .device-info-container:hover .device-ip {
+                    transform: translateY(0);
+                    opacity: 1;
+                  }
+                  .update-indicator {
+                    width: 8px;
+                    height: 8px;
+                    border-radius: 50%;
+                    background-color: var(--color-primary);
+                    display: inline-block;
+                    margin-left: 4px;
+                    vertical-align: middle;
+                  }
+                  .offline-indicator {
+                    width: 8px;
+                    height: 8px;
+                    border-radius: 50%;
+                    background-color: var(--color-negative);
+                    display: inline-block;
+                    margin-left: 4px;
+                    vertical-align: middle;
+                  }
+                  .online-indicator {
+                    width: 8px;
+                    height: 8px;
+                    border-radius: 50%;
+                    background-color: var(--color-positive);
+                    display: inline-block;
+                    margin-left: 4px;
+                    vertical-align: middle;
+                  }
+                  .device-name-container {
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+                  }
+                  .indicators-container {
+                    display: flex;
+                    align-items: center;
+                    gap: 4px;
+                  }
+                </style>
+                <ul class="list list-gap-10 collapsible-container" data-collapse-after="4">
+                  {{ range .JSON.Array "devices" }}
+                  <li>
+                    <div class="flex items-center gap-10">
+                      <div class="device-name-container grow">
+                        <span class="size-h4 block text-truncate color-primary">
+                          {{ findMatch "^([^.]+)" (.String "name") }}
+                        </span>
+                        <div class="indicators-container">
+                          {{ if (.Bool "updateAvailable") }}
+                          <span class="update-indicator" data-popover-type="text" data-popover-text="Update Available"></span>
+                          {{ end }}
+                          {{ $lastSeen := .String "lastSeen" | parseTime "rfc3339" }}
+                          {{ if not ($lastSeen.After (offsetNow "-10s")) }}
+                          {{ $lastSeenTimezoned := $lastSeen.In now.Location }}
+                          <span class="offline-indicator" data-popover-type="text"
+                            data-popover-text="Offline - Last seen {{ $lastSeenTimezoned.Format " Jan 2 3:04pm" }}"></span>
+                          {{ end }}
+                        </div>
+                      </div>
+                    </div>
+                    <div class="device-info-container">
+                      <ul class="list-horizontal-text device-info">
+                        <li>{{ .String "os" }}</li>
+                        <li>{{ .String "user" }}</li>
+                      </ul>
+                      <div class="device-ip">
+                        {{ .String "addresses.0"}}
+                      </div>
+                    </div>
+                  </li>
+                  {{ end }}
+                </ul>
+              {{ end }}
+            {{ end }}
+
 ```
 
-## Environment variables
+## Configuration Options
 
-- `TAILSCALE_API_KEY`: Your Tailscale API key
-- `TZ`: For correct times, the widget uses the container's timezone. If not already supplied, you can use this variable to provide your timezone.
+### `auth_mode` (required)
+- `"api_key"` - Use Tailscale API key authentication (default)
+- `"oauth_proxy"` - Use OAuth proxy with automatic token refresh
+
+## Usage Examples
+
+### API Key Mode (Default)
+```yaml
+options:
+  auth_mode: "api_key"
+```
+
+### OAuth Proxy Mode (Automatic Token Refresh)
+```yaml
+options:
+  auth_mode: "oauth_proxy"
+```
+
+## Authentication Modes
+
+### API Key Mode
+- Uses your Tailscale API key directly
+- Requires manual renewal every 90 days
+- **Environment variable required:** `TAILSCALE_API_KEY`
+
+### OAuth Proxy Mode
+- Uses the [Tailscale Token Manager](https://github.com/5at0ri/tailscale-token-manager) container
+- Automatically refreshes OAuth tokens - no manual updates needed
+- **Prerequisites:**
+  - Deploy the `tailscale-token-manager` container
+  - Configure OAuth application in Tailscale admin console
+  - Ensure the token manager is accessible at `tailscale-token-manager:1180`
+
+## Environment Variables
+
+- `TAILSCALE_API_KEY`: Your Tailscale API key (required for `auth_mode: "api_key"`)
+- `TZ`: Container timezone for correct timestamps (optional)

--- a/widgets/tailscale-devices-by-not-first/README.md
+++ b/widgets/tailscale-devices-by-not-first/README.md
@@ -4,7 +4,7 @@ A widget for Glance that displays all devices in your Tailscale tailnet, showing
 
 ## Option 1: API Key (Recommended)
 
-The standard implementation using Tailscale API keys. Simple to set up but requires manual key renewal every 90 days maximum.
+The standard implementation using Tailscale API keys. Simple to set up but requires manual api key renewal every 90 days maximum.
 
 ### Setup
 
@@ -15,7 +15,6 @@ The standard implementation using Tailscale API keys. Simple to set up but requi
 
 2. **Configure Widget:**
    - Set the `TAILSCALE_API_KEY` environment variable to your generated key
-   - `TZ`: For correct times, the widget uses the container's timezone. If not already supplied, you can use this variable to provide your timezone.
 
 ### Configuration
 
@@ -281,9 +280,3 @@ An alternative implementation that uses automatically refreshing OAuth tokens, e
       {{ end }}
     </ul>
 ```
-
-## Notes
-
-- **API Key Mode:** Simpler setup, requires manual renewal every 90 days
-- **OAuth Proxy Mode:** Automatic token refresh, requires additional container setup
-- Both implementations provide identical device information and functionality

--- a/widgets/tailscale-devices-by-not-first/README.md
+++ b/widgets/tailscale-devices-by-not-first/README.md
@@ -284,4 +284,4 @@ options:
 - `TZ`: Container timezone for correct timestamps (optional)
 
 ## Credits
-[5at0ri](https://github.com/5at0ri) - Incorporated oauth into the widget as an optionand made token manager (https://github.com/5at0ri/tailscale-token-manager)
+[5at0ri](https://github.com/5at0ri) - Incorporated oauth into the widget as an option and made the token manager (https://github.com/5at0ri/tailscale-token-manager)

--- a/widgets/tailscale-devices-by-not-first/README.md
+++ b/widgets/tailscale-devices-by-not-first/README.md
@@ -15,6 +15,7 @@ The standard implementation using Tailscale API keys. Simple to set up but requi
 
 2. **Configure Widget:**
    - Set the `TAILSCALE_API_KEY` environment variable to your generated key
+   - `TZ`: For correct times, the widget uses the container's timezone. If not already supplied, you can use this variable to provide your timezone.
 
 ### Configuration
 

--- a/widgets/tailscale-devices-by-not-first/README.md
+++ b/widgets/tailscale-devices-by-not-first/README.md
@@ -282,3 +282,6 @@ options:
 
 - `TAILSCALE_API_KEY`: Your Tailscale API key (required for `auth_mode: "api_key"`)
 - `TZ`: Container timezone for correct timestamps (optional)
+
+## Credits
+[5at0ri](https://github.com/5at0ri) - Incorporated oauth into the widget as an optionand made token manager (https://github.com/5at0ri/tailscale-token-manager)


### PR DESCRIPTION
@not-first has made the wonderful Tailscale widget, and I would like to add some extra functionality to it.

one key issue with Tailscale is that the api key they provide is not truly long lived; they can be set to expire at longest 90 days, meaning you would need to keep changing the api key in the config, or worse have to reload glance entirely if the key is stored in your .env file. 

I delved into this and came up with a solution using the oauth client that Tailscale allows you to set up, which will give short term api keys that refresh hourly. The benefit of this is that, combined with the container I made (https://github.com/5at0ri/tailscale-token-manager), it will always refresh a new token every hour and so will never run out/expire. This means its a one time set and forget type of thing as the client id and client secret (the .env variables you get from oauth) always stay the same and the container (Tailscale-token-manager) will always replace the hourly api key that is received by Tailscale.

I've done it so that there is both options within the widget, so if one prefers to still use the api key, in the auth_mode they can select that. Main thing is that, for this oauth mode, the container (https://github.com/5at0ri/tailscale-token-manager) is required to receive and update the api key that is received form Tailscale. I've tested it on my set up and it works great, so if anybody else could test it I would really appreciate it

also one funky quirk when comparing both api key and oauth modes from what ive seen: its almost identical apart from the api key mode shows shared in devices from outside your specific tailnet. Otherwise it functions the exact same as far as I am aware