### PR TITLE
fix(nba-scores-tracker): adding empty checks to handle edge case games

### DIFF
--- a/widgets/nba-scores-tracker-by-shmoobijones/README.md
+++ b/widgets/nba-scores-tracker-by-shmoobijones/README.md
@@ -88,7 +88,7 @@
       {{ if gt (len ($home.Array "records")) 0 }}{{ $homeRec = (index ($home.Array "records") 0).String "summary" }}{{ end }}
       <li style="display:flex;align-items:center;white-space:nowrap;gap:12px;padding:6px 0;border-bottom:1px solid var(--glance-divider);cursor:default" {{ if ne $state "STATUS_SCHEDULED" }}title="{{ $away.String "team.abbreviation" }} Box:{{ range $j,$ls := $away.Array "linescores" }}{{ if eq $j 0 }} Q1: {{ else if eq $j 1 }} Q2: {{ else if eq $j 2 }} Q3: {{ else if eq $j 3 }} Q4: {{ else }} OT: {{ end }}{{ $ls.String "value" }}{{ end }}&#10;{{ $home.String "team.abbreviation" }} Box:{{ range $j,$ls := $home.Array "linescores" }}{{ if eq $j 0 }} Q1: {{ else if eq $j 1 }} Q2: {{ else if eq $j 2 }} Q3: {{ else if eq $j 3 }} Q4: {{ else }} OT: {{ end }}{{ $ls.String "value" }}{{ end }}"{{ end }}>
         <span style="display:flex;align-items:center;width:90px;">
-          <img src="{{ $away.String "team.logo" }}" alt="{{ $away.String "team.abbreviation" }}" style="width:24px;height:24px;margin-right:4px;"/>
+          <img src="{{ if $away.String "team.logo" }}{{ $away.String "team.logo" }}{{ else }}https://a.espncdn.com/combiner/i?img=/i/teamlogos/leagues/500/nba.png{{ end }}" alt="{{ $away.String "team.abbreviation" }}" style="width:24px;height:24px;margin-right:4px;"/>
           <span style="display:flex;flex-direction:column;margin-right:0;">
             <span style="font-weight:bold;">{{ $away.String "team.abbreviation" }}</span>
             {{ if $awayRec }}<span style="font-size:0.7em;color:var(--glance-muted-text)">({{ $awayRec }})</span>{{ end }}
@@ -112,7 +112,7 @@
           {{ end }}
         </span>
         <span style="display:flex;align-items:center;width:90px;">
-          <img src="{{ $home.String "team.logo" }}" alt="{{ $home.String "team.abbreviation" }}" style="width:24px;height:24px;margin-right:4px;"/>
+          <img src="{{ if $home.String "team.logo" }}{{ $home.String "team.logo" }}{{ else }}https://a.espncdn.com/combiner/i?img=/i/teamlogos/leagues/500/nba.png{{ end }}" alt="{{ $home.String "team.abbreviation" }}" style="width:24px;height:24px;margin-right:4px;"/>
           <span style="display:flex;flex-direction:column;margin-right:0;">
             <span style="font-weight:bold;">{{ $home.String "team.abbreviation" }}</span>
             {{ if $homeRec }}<span style="font-size:0.7em;color:var(--glance-muted-text)">({{ $homeRec }})</span>{{ end }}

--- a/widgets/nba-scores-tracker-by-shmoobijones/README.md
+++ b/widgets/nba-scores-tracker-by-shmoobijones/README.md
@@ -82,14 +82,16 @@
       {{ $state := .String "competitions.0.status.type.name" }}
       {{ $away := index (.Array "competitions.0.competitors") 0 }}
       {{ $home := index (.Array "competitions.0.competitors") 1 }}
-      {{ $awayRec := (index ($away.Array "records") 0).String "summary" }}
-      {{ $homeRec := (index ($home.Array "records") 0).String "summary" }}
+      {{ $awayRec := "" }}
+      {{ if gt (len ($away.Array "records")) 0 }}{{ $awayRec = (index ($away.Array "records") 0).String "summary" }}{{ end }}
+      {{ $homeRec := "" }}
+      {{ if gt (len ($home.Array "records")) 0 }}{{ $homeRec = (index ($home.Array "records") 0).String "summary" }}{{ end }}
       <li style="display:flex;align-items:center;white-space:nowrap;gap:12px;padding:6px 0;border-bottom:1px solid var(--glance-divider);cursor:default" {{ if ne $state "STATUS_SCHEDULED" }}title="{{ $away.String "team.abbreviation" }} Box:{{ range $j,$ls := $away.Array "linescores" }}{{ if eq $j 0 }} Q1: {{ else if eq $j 1 }} Q2: {{ else if eq $j 2 }} Q3: {{ else if eq $j 3 }} Q4: {{ else }} OT: {{ end }}{{ $ls.String "value" }}{{ end }}&#10;{{ $home.String "team.abbreviation" }} Box:{{ range $j,$ls := $home.Array "linescores" }}{{ if eq $j 0 }} Q1: {{ else if eq $j 1 }} Q2: {{ else if eq $j 2 }} Q3: {{ else if eq $j 3 }} Q4: {{ else }} OT: {{ end }}{{ $ls.String "value" }}{{ end }}"{{ end }}>
         <span style="display:flex;align-items:center;width:90px;">
           <img src="{{ $away.String "team.logo" }}" alt="{{ $away.String "team.abbreviation" }}" style="width:24px;height:24px;margin-right:4px;"/>
           <span style="display:flex;flex-direction:column;margin-right:0;">
             <span style="font-weight:bold;">{{ $away.String "team.abbreviation" }}</span>
-            <span style="font-size:0.7em;color:var(--glance-muted-text)">({{ $awayRec }})</span>
+            {{ if $awayRec }}<span style="font-size:0.7em;color:var(--glance-muted-text)">({{ $awayRec }})</span>{{ end }}
           </span>
           {{ if ne $state "STATUS_SCHEDULED" }}<span style="margin-left:0;font-size:1.1em;font-weight:500;">{{ $away.String "score" }}</span>{{ end }}
         </span>
@@ -113,7 +115,7 @@
           <img src="{{ $home.String "team.logo" }}" alt="{{ $home.String "team.abbreviation" }}" style="width:24px;height:24px;margin-right:4px;"/>
           <span style="display:flex;flex-direction:column;margin-right:0;">
             <span style="font-weight:bold;">{{ $home.String "team.abbreviation" }}</span>
-            <span style="font-size:0.7em;color:var(--glance-muted-text)">({{ $homeRec }})</span>
+            {{ if $homeRec }}<span style="font-size:0.7em;color:var(--glance-muted-text)">({{ $homeRec }})</span>{{ end }}
           </span>
           {{ if ne $state "STATUS_SCHEDULED" }}<span style="margin-left:0;font-size:1.1em;font-weight:500;">{{ $home.String "score" }}</span>{{ end }}
         </span>


### PR DESCRIPTION
The current [nba-scores-tracker] is failing from the edge case of an NBA Melbourne Series Event being held with non-standard NBA teams, resulting in unexpected API structure from the ESPN API used for data sourcing. 


## Updates
- Added empty array checks to avoid template failure
- Added default to NBA league logo when no team logo is found.

## Before
<img width="396" height="261" alt="image" src="https://github.com/user-attachments/assets/cbabe7f7-7fb9-47b9-9a45-b8aa9d954de1" />

## After
<img width="349" height="214" alt="image" src="https://github.com/user-attachments/assets/5c86ee45-80f9-452d-a123-ae2b0f0e5e89" />

@ShmoobiJones please let me know if any comments or additional updates should be made.
