### PR TITLE
Add Navidrome (Subsonic) Server Stats extension

### DIFF
--- a/widgets/extensions.yml
+++ b/widgets/extensions.yml
@@ -32,3 +32,8 @@
   url: https://github.com/lukasdietrich/glance-k8s
   description: List Kubernetes nodes and applications. Also including helm charts.
   author: lukasdietrich
+
+- title: Navidrome (Subsonic) Server Stats
+  url: https://github.com/SomeCodecat/subsonic-proxy
+  description: Display statistics from your Navidrome (or Subsonic) instance and interact with them.
+  author: SomeCodecat


### PR DESCRIPTION
Show stats for your Subsonic API compatible server like Navidrome.