### PR TITLE
Add `show-thumbnails` and `limit` options to Steam Specials widget

### DIFF
--- a/widgets/steam-specials/README.md
+++ b/widgets/steam-specials/README.md
@@ -50,3 +50,16 @@
 ## Changing currency
 
 You can change the currency by changing the `cc` parameter in the URL to your country's [2 character code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). For example, to get the prices in euros, you can change the URL to `https://store.steampowered.com/api/featuredcategories?cc=eu` and then change the `$` symbol to `€` in the template.
+
+## Options
+
+When using the Steam specials widget, you can control its behavior via the `options` section in the YAML:
+
+- `show-thumbnails` (boolean)
+    - When `true`, each entry includes a thumbnail image next to the game title.
+    - When `false`, only text (title and pricing info) is shown.
+    - If omitted, it defaults to no thumbnails.
+
+- `limit` (integer)
+    - Maximum number of items to render from the specials list.
+    - `0` (or omitting the option) means “no limit” — all available items are shown.


### PR DESCRIPTION
Hey @svilenmarkov 

I added a `show-thumbnails` and `limit` options to Steam Specials widget configuration and template logic because I thought some people might appreciate having these features for your widget. Hope this looks good to you and you think it makes sense!

This is what it would look like with both options enabled:

<img width="479" height="522" alt="grafik" src="https://github.com/user-attachments/assets/23bff5cf-71bc-41f3-903c-b892549d862e" />
