### PR TITLE
Fix closing tag for gluetun widget

### DIFF
--- a/widgets/gluetun-vpn-status/README.md
+++ b/widgets/gluetun-vpn-status/README.md
@@ -66,7 +66,7 @@
                 Your VPN is not connected!
                 <span class="color-negative">●</span> 
               </div>
-            </dv>
+            </div>
           </div>
         </div>
       {{ else }}


### PR DESCRIPTION
# Gluetun widget by @Hyptu

Changed a `</dv>` to `</div>`, which is the correct closing tag. This fixes a layout bug when the VPN is not connected.