### PR TITLE
Add Stremio Activity extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ A collection of custom widgets for <a href="https://github.com/glanceapp/glance"
 * [iCal (ICS) Calendar List](https://github.com/AWildLeon/Glance-iCal-Events) - list a ICS File's upcoming events (Like Google Calendar List) (by @AWildLeon)
 * [linktiles](https://github.com/haondt/linktiles/) - display your linkding bookmarks in a configurable mosaic (by @haondt)
 * [qBittorrent Statistic](https://github.com/Panonim/qbwrapper) - display file statistics as they are being downloaded (by @panonim)
+* [Stremio Activity](https://github.com/kRYstall9/glance-stremio-activity) - display Stremio users' watching activity, including recently watched content and currently watching content. (by @kRYstall9)
 
 <br>
 

--- a/widgets/extensions.yml
+++ b/widgets/extensions.yml
@@ -47,3 +47,8 @@
   url: https://github.com/Xtrems876/glance-transmission
   description: Show Transmission downloads
   author: Xtrems876
+
+- title: Stremio Activity
+  url: https://github.com/kRYstall9/glance-stremio-activity
+  description: Display Stremio users' watching activity, including recently watched content and currently watching content.
+  author: kRYstall9


### PR DESCRIPTION
## Stremio Activity Widget

This widget displays Stremio watching activity powered by [glance-stremio-activity](https://github.com/kRYstall9/glance-stremio-activity), a self-hosted service that exposes your Stremio data via a simple API.

### Features
- **Currently watching** — shows the title, poster, and playback progress of the content currently playing
- **Last watched** — shows the most recently watched movie or TV show episode per user
- Supports **multiple users**

### Requirements
A running instance of [glance-stremio-activity](https://github.com/kRYstall9/glance-stremio-activity).

### Preview
> Screenshots generated with two users configured.

#### Live content playing
<img width="976" height="384" alt="image" src="https://github.com/user-attachments/assets/67acc8c7-7be1-4704-9e50-b0651f8c625f" />

#### No content playing
<img width="979" height="129" alt="image" src="https://github.com/user-attachments/assets/ff830e9e-cf3c-4da9-b320-74c131d68519" />
