### PR TITLE
Add Golf Calendar extension

### DIFF
--- a/widgets/extensions.yml
+++ b/widgets/extensions.yml
@@ -47,3 +47,8 @@
   url: https://github.com/Xtrems876/glance-transmission
   description: Show Transmission downloads
   author: Xtrems876
+
+- title: Golf Calendar
+  url: https://github.com/ryantcarter/glance-golf
+  description: Aggregates upcoming golf events from PGA Tour, DP World Tour, and LIV Golf into a unified feed.
+  author: ryantcarter


### PR DESCRIPTION
## Summary
Adds the Golf Calendar extension to the community extensions list.

**Repository:** https://github.com/ryantcarter/glance-golf

## What it does
A lightweight FastAPI service that aggregates upcoming golf events from multiple professional tours into a unified JSON feed:

- **PGA Tour** - via CalendarLabs ICS feed
- **DP World Tour** - via CalendarLabs ICS feed  
- **LIV Golf** - via CalendarLabs ICS feed

### Features
- Merges all 3 tours into one chronologically sorted feed
- Multi-day tournaments displayed as single entries with date ranges
- 30-minute caching to avoid excessive requests
- Filter by tour or get all events combined
- Returns JSON for use with Glance's custom-api widget

## Preview
Shows upcoming golf tournaments with tour name, date range, location, and duration.

## Installation
Runs as a Docker container alongside Glance on a shared user-defined network.