### PR TITLE
Add Proxmox VE Metrics extension

### DIFF
--- a/widgets/extensions.yml
+++ b/widgets/extensions.yml
@@ -62,3 +62,8 @@
   url: https://github.com/lumitesi/glance-esxi-stats
   description: Display server, VM, and datastore statistics for VMware ESXi.
   author: lumitesi
+
+- title: Proxmox VE Metrics
+  url: https://github.com/drumandbytes/pve-metrics-exporter
+  description: Prometheus + Glance JSON API exporter for Proxmox VE - node/VM/LXC resource usage and hardware sensor temperatures (most exporters skip temperatures entirely).
+  author: drumandbytes


### PR DESCRIPTION
Adds [pve-metrics-exporter](https://github.com/drumandbytes/pve-metrics-exporter) to the extensions list.

A Proxmox VE exporter with two outputs from one shared data fetch:
- `/metrics` — a real Prometheus exporter (node/VM/LXC resource usage + hardware sensor temperatures, including per-sensor critical thresholds)
- `/api/summary` — the same data as flat, pre-computed JSON meant for a Glance `custom-api` widget to render directly, no data-munging in the template

What sets it apart from other Proxmox widgets/exporters: most skip hardware sensor temperatures entirely, since Proxmox's own API returns `lm-sensors` output as a JSON-*encoded string* rather than a nested object — an extra parsing step most tools don't bother with. This one does that parsing server-side and exposes clean CPU/GPU/NVMe/chipset temperatures (in both °C and °F), including per-sensor critical thresholds where the hardware reports one, alongside the usual node/VM/LXC CPU/RAM/disk stats.

Listed as an extension rather than a `custom-api` widget submission since it requires the exporter running alongside Glance to do the actual data parsing (Proxmox's own API embeds sensor data as a JSON-encoded string, not a nested object) — per the CONTRIBUTING.md guidance for widgets needing an additional local API.